### PR TITLE
Cargo fmt and clippy checks in pipelines (see #36)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,27 @@ name: CI
 on: [push]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install nightly toolchain for RUST
+        run: rustup install nightly
+      - name: Check README.md synchronization
+        run: |
+          cargo install --force cargo-sync-readme
+          cargo sync-readme -c
+      - name: Check formatting
+        run: |
+          rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+          cargo +nightly fmt --all -- --check
+      - name: Scan code
+        run: |
+          rustup component add clippy
+          cargo clippy --all-features -- -D warnings -A clippy::needless_doctest_main -A clippy::type_complexity
+
   build-linux:
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -12,6 +32,7 @@ jobs:
         run: cargo test --verbose
 
   build-linux-json:
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -21,6 +42,7 @@ jobs:
         run: cargo test --verbose --features json
 
   build-linux-ron:
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -30,6 +52,7 @@ jobs:
         run: cargo test --verbose --features ron-impl
 
   build-linux-toml:
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -39,6 +62,7 @@ jobs:
         run: cargo test --verbose --features toml-impl
 
   build-linux-arc:
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -48,6 +72,7 @@ jobs:
         run: cargo test --verbose --features arc
 
   build-windows:
+    needs: check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -57,6 +82,7 @@ jobs:
         run: cargo test --verbose
 
   build-windows-json:
+    needs: check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -66,6 +92,7 @@ jobs:
         run: cargo test --verbose --features json
 
   build-windows-ron:
+    needs: check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -75,6 +102,7 @@ jobs:
         run: cargo test --verbose --features ron-impl
 
   build-windows-toml:
+    needs: check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -84,6 +112,7 @@ jobs:
         run: cargo test --verbose --features toml-impl
 
   build-windows-arc:
+    needs: check
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -91,12 +120,3 @@ jobs:
         run: cargo build --verbose --features arc
       - name: Test (Arc support)
         run: cargo test --verbose --features arc
-
-  check-readme:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install cargo-sync-readme
-        run: cargo install --force cargo-sync-readme
-      - name: Check
-        run: cargo sync-readme -c

--- a/src/context.rs
+++ b/src/context.rs
@@ -98,9 +98,7 @@ pub trait Inspect<'a, Ctx, Inspected, Method = ()> {
 
 /// No-context universal implementor.
 impl<'a, T, C, M> Inspect<'a, C, (), M> for T {
-  fn inspect(_: &'a mut C) -> () {
-    ()
-  }
+  fn inspect(_: &'a mut C) {}
 }
 
 /// Immutable full-context universal implementator.

--- a/src/json.rs
+++ b/src/json.rs
@@ -6,9 +6,9 @@
 
 use serde::Deserialize;
 use serde_json::{self, from_reader};
-use std::io;
 use std::fmt;
 use std::fs::File;
+use std::io;
 use std::path::PathBuf;
 
 use crate::key::Key;
@@ -27,7 +27,7 @@ pub enum JsonError {
   /// The file specified by the key failed to open.
   CannotOpenFile(PathBuf, io::Error),
   /// The input key doesn’t provide enough information to open a file.
-  NoKey
+  NoKey,
 }
 
 impl fmt::Display for JsonError {
@@ -39,24 +39,21 @@ impl fmt::Display for JsonError {
         write!(f, "cannot open file {}: {}", path.display(), e)
       }
 
-      JsonError::NoKey => f.write_str("no path key available")
+      JsonError::NoKey => f.write_str("no path key available"),
     }
   }
 }
 
 impl<C, K, T> Load<C, K, Json> for T
-where K: Key + Into<Option<PathBuf>>,
-      T: 'static + for<'de> Deserialize<'de> {
+where
+  K: Key + Into<Option<PathBuf>>,
+  T: 'static + for<'de> Deserialize<'de>,
+{
   type Error = JsonError;
 
-  fn load(
-    key: K,
-    _: &mut Storage<C, K>,
-    _: &mut C
-  ) -> Result<Loaded<Self, K>, Self::Error> {
+  fn load(key: K, _: &mut Storage<C, K>, _: &mut C) -> Result<Loaded<Self, K>, Self::Error> {
     if let Some(path) = key.into() {
-      let file = File::open(&path)
-          .map_err(|ioerr| JsonError::CannotOpenFile(path, ioerr))?;
+      let file = File::open(&path).map_err(|ioerr| JsonError::CannotOpenFile(path, ioerr))?;
 
       from_reader(file)
         .map(Loaded::without_dep)

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,8 @@
 //! Module exporting all key types recognized by this crate.
 
 use any_cache::CacheKey;
-use std::hash::{Hash, Hasher};
 use std::fmt::{self, Display};
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::path::{Component, Path, PathBuf};
 
@@ -30,12 +30,13 @@ pub enum SimpleKey {
 }
 
 impl SimpleKey {
-  pub fn from_path<P>(path: P) -> Self where P: AsRef<Path> {
+  pub fn from_path<P>(path: P) -> Self
+  where P: AsRef<Path> {
     SimpleKey::Path(path.as_ref().to_owned())
   }
 }
 
-impl<'a>  From<&'a Path> for SimpleKey {
+impl<'a> From<&'a Path> for SimpleKey {
   fn from(path: &Path) -> Self {
     SimpleKey::from_path(path)
   }
@@ -51,7 +52,7 @@ impl Into<Option<PathBuf>> for SimpleKey {
   fn into(self) -> Option<PathBuf> {
     match self {
       SimpleKey::Path(path) => Some(path),
-      _ => None
+      _ => None,
     }
   }
 }
@@ -72,7 +73,7 @@ impl Display for SimpleKey {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {
       SimpleKey::Path(ref path) => write!(f, "{}", path.display()),
-      SimpleKey::Logical(ref name) => write!(f, "{}", name)
+      SimpleKey::Logical(ref name) => write!(f, "{}", name),
     }
   }
 }
@@ -108,12 +109,19 @@ impl<K, T> PrivateKey<K, T> {
   }
 }
 
-impl<K, T> Hash for PrivateKey<K, T> where K: Hash {
-  fn hash<H>(&self, state: &mut H) where H: Hasher {
+impl<K, T> Hash for PrivateKey<K, T>
+where K: Hash
+{
+  fn hash<H>(&self, state: &mut H)
+  where H: Hasher {
     self.0.hash(state)
   }
 }
 
-impl<K, T> CacheKey for PrivateKey<K, T> where T: 'static, K: Key {
+impl<K, T> CacheKey for PrivateKey<K, T>
+where
+  T: 'static,
+  K: Key,
+{
   type Target = Res<T>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,14 +574,19 @@
 //! [RON]: https://github.com/ron-rs/ron
 
 pub mod context;
-#[cfg(feature = "json")] pub mod json;
-#[cfg(feature = "ron-impl")] pub mod ron;
-#[cfg(feature = "toml-impl")] pub mod toml;
+#[cfg(feature = "json")]
+pub mod json;
 pub mod key;
 pub mod load;
 pub mod res;
+#[cfg(feature = "ron-impl")]
+pub mod ron;
+#[cfg(feature = "toml-impl")]
+pub mod toml;
 
 pub use crate::context::Inspect;
 pub use crate::key::{Key, SimpleKey};
-pub use crate::load::{Discovery, Load, Loaded, Storage, Store, StoreError, StoreErrorOr, StoreOpt};
+pub use crate::load::{
+  Discovery, Load, Loaded, Storage, Store, StoreError, StoreErrorOr, StoreOpt,
+};
 pub use crate::res::Res;

--- a/src/load.rs
+++ b/src/load.rs
@@ -32,8 +32,9 @@ use crate::res::Res;
 ///
 /// [`SimpleKey`]: crate::key::SimpleKey
 pub trait Load<C, K, Method = ()>: 'static + Sized
-where K: Key,
-      Method: ?Sized {
+where
+  K: Key,
+  Method: ?Sized, {
   /// Type of error that might happen while loading.
   type Error: Display + 'static;
 
@@ -43,22 +44,14 @@ where K: Key,
   ///
   /// The result type is used to register for dependency events. If you do not need any, you can
   /// lift your return value in [`Loaded`] with `your_value.into()`.
-  fn load(
-    key: K,
-    storage: &mut Storage<C, K>,
-    ctx: &mut C,
-  ) -> Result<Loaded<Self, K>, Self::Error>;
+  fn load(key: K, storage: &mut Storage<C, K>, ctx: &mut C)
+    -> Result<Loaded<Self, K>, Self::Error>;
 
   // FIXME: add support for redeclaring the dependencies?
   /// Function called when a resource must be reloaded.
   ///
   /// The default implementation of that function calls [`Load::load`] and returns its result.
-  fn reload(
-    &self,
-    key: K,
-    storage: &mut Storage<C, K>,
-    ctx: &mut C,
-  ) -> Result<Self, Self::Error> {
+  fn reload(&self, key: K, storage: &mut Storage<C, K>, ctx: &mut C) -> Result<Self, Self::Error> {
     Self::load(key, storage, ctx).map(|lr| lr.res)
   }
 }
@@ -127,8 +120,10 @@ pub struct Storage<C, K> {
   metadata: HashMap<K, ResMetaData<C, K>>,
 }
 
-impl<C, K> Storage<C, K> where K: Key {
-  fn new(canon_root: PathBuf) -> Self{
+impl<C, K> Storage<C, K>
+where K: Key
+{
+  fn new(canon_root: PathBuf) -> Self {
     Storage {
       canon_root,
       cache: HashCache::new(),
@@ -146,16 +141,11 @@ impl<C, K> Storage<C, K> where K: Key {
   ///
   /// The resource might be refused for several reasons. Further information in the documentation of
   /// the [`StoreError`] error type.
-  fn inject<T, M>(
-    &mut self,
-    key: K,
-    resource: T,
-    deps: Vec<K>,
-  ) -> Result<Res<T>, StoreError<K>>
+  fn inject<T, M>(&mut self, key: K, resource: T, deps: Vec<K>) -> Result<Res<T>, StoreError<K>>
   where T: Load<C, K, M> {
     // we forbid having two resources sharing the same key
     if self.metadata.contains_key(&key) {
-      return Err(StoreError::AlreadyRegisteredKey(key.clone()));
+      return Err(StoreError::AlreadyRegisteredKey(key));
     }
 
     // wrap the resource to make it shared mutably
@@ -185,7 +175,7 @@ impl<C, K> Storage<C, K> where K: Key {
       self
         .deps
         .entry(dep.clone().prepare_key(root))
-        .or_insert(Vec::new())
+        .or_insert_with(Vec::new)
         .push(key.clone());
     }
 
@@ -214,7 +204,9 @@ impl<C, K> Storage<C, K> where K: Key {
     ctx: &mut C,
     _: M,
   ) -> Result<Res<T>, StoreErrorOr<T, C, K, M>>
-  where T: Load<C, K, M> {
+  where
+    T: Load<C, K, M>,
+  {
     let key = key.clone().prepare_key(self.root());
 
     // move the key into pkey to prevent an allocation and remove it after use
@@ -244,11 +236,13 @@ impl<C, K> Storage<C, K> where K: Key {
     proxy: P,
     ctx: &mut C,
   ) -> Result<Res<T>, StoreError<K>>
-  where T: Load<C, K>,
-        P: FnOnce() -> T {
+  where
+    T: Load<C, K>,
+    P: FnOnce() -> T,
+  {
     self
       .get(key, ctx)
-      .or_else(|_| self.inject::<T, ()>(key.clone().into(), proxy(), Vec::new()))
+      .or_else(|_| self.inject::<T, ()>(key.clone(), proxy(), Vec::new()))
   }
 
   /// Get a resource from the [`Storage`] for the given key by using a specific method. If it fails, a
@@ -261,11 +255,13 @@ impl<C, K> Storage<C, K> where K: Key {
     ctx: &mut C,
     method: M,
   ) -> Result<Res<T>, StoreError<K>>
-  where T: Load<C, K, M>,
-        P: FnOnce() -> T {
+  where
+    T: Load<C, K, M>,
+    P: FnOnce() -> T,
+  {
     self
       .get_by(key, ctx, method)
-      .or_else(|_| self.inject::<T, M>(key.clone().into(), proxy(), Vec::new()))
+      .or_else(|_| self.inject::<T, M>(key.clone(), proxy(), Vec::new()))
   }
 }
 
@@ -281,7 +277,9 @@ pub enum StoreError<K> {
   AlreadyRegisteredKey(K),
 }
 
-impl<K> Display for StoreError<K> where K: Display {
+impl<K> Display for StoreError<K>
+where K: Display
+{
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {
       StoreError::RootDoesNotExist(ref path) => write!(f, "root {} doesn’t exist", path.display()),
@@ -291,7 +289,10 @@ impl<K> Display for StoreError<K> where K: Display {
 }
 
 /// Either a store error or a resource loading error.
-pub enum StoreErrorOr<T, C, K, M = ()> where T: Load<C, K, M>, K: Key {
+pub enum StoreErrorOr<T, C, K, M = ()>
+where
+  T: Load<C, K, M>,
+  K: Key, {
   /// A store error.
   StoreError(StoreError<K>),
   /// A resource error.
@@ -299,9 +300,11 @@ pub enum StoreErrorOr<T, C, K, M = ()> where T: Load<C, K, M>, K: Key {
 }
 
 impl<T, C, K, M> Clone for StoreErrorOr<T, C, K, M>
-where T: Load<C, K, M>,
-      T::Error: Clone,
-      K: Key {
+where
+  T: Load<C, K, M>,
+  T::Error: Clone,
+  K: Key,
+{
   fn clone(&self) -> Self {
     match *self {
       StoreErrorOr::StoreError(ref e) => StoreErrorOr::StoreError(e.clone()),
@@ -311,15 +314,19 @@ where T: Load<C, K, M>,
 }
 
 impl<T, C, K, M> Eq for StoreErrorOr<T, C, K, M>
-where T: Load<C, K, M>,
-      T::Error: Eq,
-      K: Key {
+where
+  T: Load<C, K, M>,
+  T::Error: Eq,
+  K: Key,
+{
 }
 
 impl<T, C, K, M> PartialEq for StoreErrorOr<T, C, K, M>
-where T: Load<C, K, M>,
-      T::Error: PartialEq,
-      K: Key {
+where
+  T: Load<C, K, M>,
+  T::Error: PartialEq,
+  K: Key,
+{
   fn eq(&self, rhs: &Self) -> bool {
     match (self, rhs) {
       (&StoreErrorOr::StoreError(ref a), &StoreErrorOr::StoreError(ref b)) => a == b,
@@ -330,9 +337,11 @@ where T: Load<C, K, M>,
 }
 
 impl<T, C, K, M> fmt::Debug for StoreErrorOr<T, C, K, M>
-where T: Load<C, K, M>,
-      T::Error: fmt::Debug,
-      K: Key + fmt::Debug {
+where
+  T: Load<C, K, M>,
+  T::Error: fmt::Debug,
+  K: Key + fmt::Debug,
+{
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {
       StoreErrorOr::StoreError(ref e) => f.debug_tuple("StoreError").field(e).finish(),
@@ -342,9 +351,11 @@ where T: Load<C, K, M>,
 }
 
 impl<T, C, K, M> Display for StoreErrorOr<T, C, K, M>
-where T: Load<C, K, M>,
-      T::Error: fmt::Debug,
-      K: Key + Display {
+where
+  T: Load<C, K, M>,
+  T::Error: fmt::Debug,
+  K: Key + Display,
+{
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {
       StoreErrorOr::StoreError(ref e) => e.fmt(f),
@@ -366,25 +377,29 @@ struct Synchronizer<C, K> {
   // watcher receiver part of the channel
   watcher_rx: Receiver<DebouncedEvent>,
   // used to accept or ignore new discoveries
-  discovery: Discovery<C, K>
+  discovery: Discovery<C, K>,
 }
 
-impl<C, K> Synchronizer<C, K> where K: Key {
+impl<C, K> Synchronizer<C, K>
+where K: Key
+{
   fn new(
     watcher: RecommendedWatcher,
     watcher_rx: Receiver<DebouncedEvent>,
-    discovery: Discovery<C, K>
-  ) -> Self {
+    discovery: Discovery<C, K>,
+  ) -> Self
+  {
     Synchronizer {
       dirties: HashSet::new(),
       watcher,
       watcher_rx,
-      discovery
+      discovery,
     }
   }
 
   /// Dequeue any file system events.
-  fn dequeue_fs_events(&mut self, storage: &mut Storage<C, K>, ctx: &mut C) where K: for<'a> From<&'a Path> {
+  fn dequeue_fs_events(&mut self, storage: &mut Storage<C, K>, ctx: &mut C)
+  where K: for<'a> From<&'a Path> {
     for event in self.watcher_rx.try_iter() {
       match event {
         DebouncedEvent::Write(ref path) | DebouncedEvent::Create(ref path) => {
@@ -430,7 +445,8 @@ impl<C, K> Synchronizer<C, K> where K: Key {
   }
 
   /// Synchronize the [`Storage`] by updating the resources that ought to.
-  fn sync(&mut self, storage: &mut Storage<C, K>, ctx: &mut C) where K: for<'a> From<&'a Path> {
+  fn sync(&mut self, storage: &mut Storage<C, K>, ctx: &mut C)
+  where K: for<'a> From<&'a Path> {
     self.dequeue_fs_events(storage, ctx);
     self.reload_dirties(storage, ctx);
   }
@@ -442,7 +458,9 @@ pub struct Store<C, K> {
   synchronizer: Synchronizer<C, K>,
 }
 
-impl<C, K> Store<C, K> where K: Key {
+impl<C, K> Store<C, K>
+where K: Key
+{
   /// Create a new store.
   ///
   /// # Failures
@@ -478,7 +496,8 @@ impl<C, K> Store<C, K> where K: Key {
   }
 
   /// Synchronize the [`Store`] by updating the resources that ought to with a provided context.
-  pub fn sync(&mut self, ctx: &mut C) where K: for<'a> From<&'a Path> {
+  pub fn sync(&mut self, ctx: &mut C)
+  where K: for<'a> From<&'a Path> {
     self.synchronizer.sync(&mut self.storage, ctx);
   }
 }
@@ -503,7 +522,7 @@ impl<C, K> DerefMut for Store<C, K> {
 pub struct StoreOpt<C, K> {
   root: PathBuf,
   debounce_duration: Duration,
-  discovery: Discovery<C, K>
+  discovery: Discovery<C, K>,
 }
 
 impl<C, K> Default for StoreOpt<C, K> {
@@ -511,7 +530,7 @@ impl<C, K> Default for StoreOpt<C, K> {
     StoreOpt {
       root: PathBuf::from("."),
       debounce_duration: Duration::from_millis(50),
-      discovery: Discovery::default()
+      discovery: Discovery::default(),
     }
   }
 }
@@ -568,10 +587,7 @@ impl<C, K> StoreOpt<C, K> {
   /// Defaults to `Discovery::default()`.
   #[inline]
   pub fn set_discovery(self, discovery: Discovery<C, K>) -> Self {
-    StoreOpt {
-      discovery,
-      ..self
-    }
+    StoreOpt { discovery, ..self }
   }
 
   /// Get the discovery mechanism.
@@ -602,9 +618,10 @@ impl<C, K> Discovery<C, K> {
   /// all discovery, that’s also possible.
   ///
   /// [`get`]: crate::load::Storage::get
-  pub fn new<F>(f: F) -> Self where F: 'static + FnMut(&Path, &mut Storage<C, K>, &mut C) {
+  pub fn new<F>(f: F) -> Self
+  where F: 'static + FnMut(&Path, &mut Storage<C, K>, &mut C) {
     Discovery {
-      closure: Box::new(f)
+      closure: Box::new(f),
     }
   }
 

--- a/src/res.rs
+++ b/src/res.rs
@@ -1,9 +1,11 @@
 //! Shareable resources.
 
-#[cfg(feature = "arc")] use std::sync::{Arc, Mutex, MutexGuard};
-#[cfg(not(feature = "arc"))] use std::{
+#[cfg(feature = "arc")]
+use std::sync::{Arc, Mutex, MutexGuard};
+#[cfg(not(feature = "arc"))]
+use std::{
   cell::{Ref, RefCell, RefMut},
-  rc::Rc
+  rc::Rc,
 };
 
 /// Shareable resource type.

--- a/src/ron.rs
+++ b/src/ron.rs
@@ -47,8 +47,10 @@ impl fmt::Display for RonError {
 }
 
 impl<C, K, T> Load<C, K, Ron> for T
-where K: Key + Into<Option<PathBuf>>,
-      T: 'static + for<'de> Deserialize<'de>, {
+where
+  K: Key + Into<Option<PathBuf>>,
+  T: 'static + for<'de> Deserialize<'de>,
+{
   type Error = RonError;
 
   fn load(key: K, _: &mut Storage<C, K>, _: &mut C) -> Result<Loaded<Self, K>, Self::Error> {

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -47,8 +47,10 @@ impl fmt::Display for TomlError {
 }
 
 impl<C, K, T> Load<C, K, Toml> for T
-where K: Key + Into<Option<PathBuf>>,
-      T: 'static + for<'de> Deserialize<'de>, {
+where
+  K: Key + Into<Option<PathBuf>>,
+  T: 'static + for<'de> Deserialize<'de>,
+{
   type Error = TomlError;
 
   fn load(key: K, _: &mut Storage<C, K>, _: &mut C) -> Result<Loaded<Self, K>, Self::Error> {


### PR DESCRIPTION
This PR is somewhat redundant to https://github.com/phaazon/warmy/pull/36 and does not solve the problem of that PR.
I have formatted the code with `cargo fmt` and implemented the format check into the GitHub pipelines. I have also added clippy (rustc wrapper) with `-D warnings` (to fail when a warning has been found) and I also added this to the GitHub pipelines.
Also, all jobs now depend on the format, clippy and README-sync check and are only executed when these are passing.
I usually prefer this as it saves GitHub Actions time when basic checks are not passing.

Just as a suggestion, maybe you should consider using the `cargo fmt` style (although it has the existing brace-on-line issue) now. Later on, when this has been solved, this small detail can be formatted again I guess.

Feel free to reject if you don't feel like it or dislike the changes to the actions or so. I am happy to help finding a solution!